### PR TITLE
Parse as strings Strimzi and Istio enabled flags

### DIFF
--- a/charts/lh-operator/templates/deployment.yaml
+++ b/charts/lh-operator/templates/deployment.yaml
@@ -50,9 +50,9 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: LHO_STRIMZI_ENABLED
-            value: {{ .Values.strimzi.enabled }}
+            value: "{{ .Values.strimzi.enabled }}"
           - name: LHO_ISTIO_ENABLED
-            value: {{ .Values.istio.enabled }}
+            value: "{{ .Values.istio.enabled }}"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Either K8s or yaml or both don't like booleans they need to be strings :(