### PR TITLE
Add feature flag to use cert-manager

### DIFF
--- a/charts/lh-operator/templates/deployment.yaml
+++ b/charts/lh-operator/templates/deployment.yaml
@@ -53,6 +53,8 @@ spec:
             value: "{{ .Values.strimzi.enabled }}"
           - name: LHO_ISTIO_ENABLED
             value: "{{ .Values.istio.enabled }}"
+          - name: LHO_CERTMANAGER_ENABLED
+            value: "{{ .Values.certManager.enabled }}"
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/lh-operator/values.yaml
+++ b/charts/lh-operator/values.yaml
@@ -37,6 +37,9 @@ istio:
   # Specifies if the operator can create Istio virtualservices
   enabled: false
 
+certManager:
+  enabled: false
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
## Context

lh-operator is capable to generate certificates if `LHO_CERTMANAGER_ENABLED` is `true` this PR adds the required values and environment variable to the deployment to support this feature.